### PR TITLE
Bump keyseq to 0.4.0 and add `action::trigger*` convenience systems, CHANGE NOTATION, and prep for bevy-input-sequence 0.6.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.5.0] - 2024-04-23
+## [unreleased]
+
+## [0.6.0] - 2024-11-24
+
+## [0.5.0] - 2024-06-05
 
 ### Features
 - Optimize look ups to incrementally search using O(log n) instead of O(m^2 log n). See [PR #7](https://github.com/not-elm/bevy-input-sequence/pull/7) for more details.
+
+### Bugs
+- Fix bug where "W A S D" and "A S" sequences would match the latter pattern when "W A S P" was typed.
 
 ## [0.4.0] - 2024-04-23
 
@@ -15,7 +22,7 @@ All notable changes to this project will be documented in this file.
 - Use plugin.
 - Can configure schedule and system set.
 - Remove `GamepadEvent`; use system with input `In<Gamepad>`.
-- Add `IntoCondSystem` that adds `only_if()` conditions to `IntoSystems`.
+- Add `IntoCondSystem` that adds `only_if()` conditi:ons to `IntoSystems`.
 - Add `only_if` example.
 - Add `prelude` module for glob imports.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [0.6.0] - 2024-11-24
 
+- Add `action::trigger` and `action::trigger_targets` convenience systems.
+- Bump keyseq to 0.4.0, which changes notation to be more standard: `Ctrl-A`
+  instead of `ctrl-A`.
+
 ## [0.5.0] - 2024-06-05
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.4.0] - 2024-04-23
+## [0.5.0] - 2024-04-23
+
+### Features
+- Optimize look ups to incrementally search using O(log n) instead of O(m^2 log n). See [PR #7](https://github.com/not-elm/bevy-input-sequence/pull/7) for more details.
 
 ## [0.4.0] - 2024-04-23
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ path = "examples/multiple_input.rs"
 [dependencies]
 bevy = { version = "0.14", default-features = false, features = [] }
 trie-rs = { version = "0.4" }
-keyseq = { version = "0.4.0", features = [ "bevy" ] }
+keyseq = { version = "0.4.1", features = [ "bevy" ] }
 
 [dev-dependencies]
 bevy = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy-input-sequence"
-description = "Recognizes input sequences and send events"
-version = "0.5.0"
+description = "Recognizes and acts on input sequences"
+version = "0.6.0"
 edition = "2021"
 authors = ["elm", "Shane Celis <shane.celis@gmail.com>"]
 keywords = [
@@ -18,21 +18,17 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/elm-register/bevy-input-sequence"
 
-
 [[example]]
 name = "keycode"
 path = "examples/keycode.rs"
-
 
 [[example]]
 name = "gamepad_button"
 path = "examples/gamepad_button.rs"
 
-
 [[example]]
 name = "multiple_input"
 path = "examples/multiple_input.rs"
-
 
 [dependencies]
 bevy = { version = "0.14", default-features = false, features = [] }
@@ -43,3 +39,6 @@ keyseq = { version = "0.4.0", features = [ "bevy" ] }
 bevy = "0.14"
 trybuild = "1.0"
 version-sync = "0.9"
+
+[patch.crates-io]
+keyseq = { path = "../keyseq" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ path = "examples/multiple_input.rs"
 [dependencies]
 bevy = { version = "0.14", default-features = false, features = [] }
 trie-rs = { version = "0.4" }
-keyseq = { version = "0.3.0", features = [ "bevy" ] }
+keyseq = { version = "0.4.0", features = [ "bevy" ] }
 
 [dev-dependencies]
 bevy = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,3 @@ keyseq = { version = "0.4.0", features = [ "bevy" ] }
 bevy = "0.14"
 trybuild = "1.0"
 version-sync = "0.9"
-
-[patch.crates-io]
-keyseq = { path = "../keyseq" }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bevy-input-sequence
 
-Detect input sequences from the keyboard or a gamepad.
+Recognizes and acts on input sequences from the keyboard or a gamepad.
 
 # Use Cases
 
@@ -42,6 +42,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
+    // Add key sequence.
     commands.add(
         KeySequence::new(say_hello, 
                          keyseq! { H I })
@@ -63,11 +64,11 @@ with `action::send_event()`.
 use bevy::prelude::*;
 use bevy_input_sequence::prelude::*;
 
-// Define an event
+/// Define an event.
 #[derive(Event, Clone, Debug)]
 struct MyEvent;
 
-// Add event as an key sequence
+/// Add event as an key sequence.
 fn main() {
     App::new()
         .add_plugins(MinimalPlugins)
@@ -101,11 +102,11 @@ take an input of `Gamepad`.
 use bevy::prelude::*;
 use bevy_input_sequence::prelude::*;
 
-// Define an event
+/// Define an event.
 #[derive(Event, Clone, Debug)]
 struct MyEvent(Gamepad);
 
-// Add event as an key sequence
+/// Add event as an key sequence.
 fn main() {
     App::new()
         .add_plugins(MinimalPlugins)
@@ -132,6 +133,41 @@ fn check_events(mut events: EventReader<MyEvent>) {
 }
 ```
 
+## Trigger an Event on Key Sequence
+
+You can also trigger an event with `action::trigger()` or `action::trigger_targets()`.
+
+```rust
+use bevy::prelude::*;
+use bevy_input_sequence::prelude::*;
+
+/// Define an event.
+#[derive(Event, Clone, Debug)]
+struct MyEvent;
+
+/// Add event as an key sequence.
+fn main() {
+    App::new()
+        .add_plugins(MinimalPlugins)
+        .add_plugins(InputSequencePlugin::default())
+        .add_event::<MyEvent>()
+        .add_systems(Startup, setup)
+        .observe(check_trigger)
+        .update(); // Normally you'd run it here.
+}
+
+fn setup(mut commands: Commands) {
+    commands.add(
+        KeySequence::new(action::trigger(MyEvent), 
+                         keyseq! { Ctrl-E L M })
+    );
+}
+
+fn check_trigger(mut trigger: Trigger<MyEvent>) {
+    info!("got event {:?}", trigger.event());
+}
+```
+
 ## KeySequence Creation Patterns
 
 `KeySequence::new` now returns `KeySequenceBuilder`, which implements `Command`.
@@ -152,8 +188,8 @@ fn create_key_sequence(mut commands: Commands) {
 }
 
 fn create_key_sequence_and_add_it_to_an_entity(mut commands: Commands) {
-    let parent = commands.spawn_empty().id();
-    commands.entity(parent).add(KeySequence::new(
+    let id = commands.spawn_empty().id();
+    commands.entity(id).add(KeySequence::new(
         action::send_event(MyEvent), 
         keyseq! { Ctrl-E L M }
     ));
@@ -254,8 +290,8 @@ cargo run --example run_if
 
 | bevy-input-sequence | bevy |
 |---------------------|------|
-| 0.5                 | 0.14 |
-| 0.3 ~ 0.4.0         | 0.13 |
+| 0.5 ~ 0.6           | 0.14 |
+| 0.3 ~ 0.4           | 0.13 |
 | 0.2                 | 0.12 |
 | 0.1                 | 0.11 |
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ fn main() {
 fn setup(mut commands: Commands) {
     commands.add(
         KeySequence::new(action::send_event(MyEvent), 
-                         keyseq! { ctrl-E L M })
+                         keyseq! { Ctrl-E L M })
     );
 }
 
@@ -147,7 +147,7 @@ struct MyEvent;
 fn create_key_sequence(mut commands: Commands) {
     commands.add(KeySequence::new(
         action::send_event(bevy::app::AppExit::default()), 
-        keyseq! { ctrl-E L M }
+        keyseq! { Ctrl-E L M }
     ));
 }
 
@@ -155,12 +155,12 @@ fn create_key_sequence_and_add_it_to_an_entity(mut commands: Commands) {
     let parent = commands.spawn_empty().id();
     commands.entity(parent).add(KeySequence::new(
         action::send_event(MyEvent), 
-        keyseq! { ctrl-E L M }
+        keyseq! { Ctrl-E L M }
     ));
     // OR
     commands.spawn_empty().add(KeySequence::new(
         action::send_event(MyEvent), 
-        keyseq! { ctrl-E L M }
+        keyseq! { Ctrl-E L M }
     ));
 }
 ```
@@ -178,7 +178,7 @@ fn create_key_sequence_within_command(mut commands: Commands) {
     commands.add(|world: &mut World| {
         let builder = KeySequence::new(
             move || { info!("got it"); },
-            keyseq! { ctrl-E L M }
+            keyseq! { Ctrl-E L M }
         );
         let key_sequence: KeySequence = builder.build(world);
         // And then put it somewhere? It ought to go as a component.
@@ -199,7 +199,7 @@ cargo run --example keycode
 
 ## keymod
 
-The `keymod` example recognizes `ctrl-W ctrl-D ctrl-S ctrl-A` and fires an event.
+The `keymod` example recognizes `Ctrl-W Ctrl-D Ctrl-S Ctrl-A` and fires an event.
 
 ``` sh
 cargo run --example keymod

--- a/examples/keycode.rs
+++ b/examples/keycode.rs
@@ -39,7 +39,7 @@ fn setup(mut commands: Commands) {
     commands.add(
         KeySequence::new(
             action::send_event(MyEvent(Direction::CounterClockwise)),
-            keyseq!(W A S D),
+            keyseq!{ W A S D },
         )
         .time_limit(Duration::from_secs(1)),
     );

--- a/examples/keymod.rs
+++ b/examples/keymod.rs
@@ -18,7 +18,7 @@ fn setup(mut commands: Commands) {
     commands.add(
         KeySequence::new(
             action::send_event(MyEvent),
-            keyseq!(Ctrl-W Ctrl-D Ctrl-S Ctrl-A),
+            keyseq! { Ctrl-W Ctrl-D Ctrl-S Ctrl-A },
         )
         .time_limit(Duration::from_secs(1)),
     );

--- a/examples/keymod.rs
+++ b/examples/keymod.rs
@@ -18,11 +18,11 @@ fn setup(mut commands: Commands) {
     commands.add(
         KeySequence::new(
             action::send_event(MyEvent),
-            keyseq!(ctrl-W ctrl-D ctrl-S ctrl-A),
+            keyseq!(Ctrl-W Ctrl-D Ctrl-S Ctrl-A),
         )
         .time_limit(Duration::from_secs(1)),
     );
-    println!("Press ctrl-W ctrl-D ctrl-S ctrl-A to emit event.");
+    println!("Press Ctrl-W Ctrl-D Ctrl-S Ctrl-A to emit event.");
 }
 
 fn input_sequence_event_system(mut er: EventReader<MyEvent>) {

--- a/examples/multiple_input.rs
+++ b/examples/multiple_input.rs
@@ -17,7 +17,7 @@ fn main() {
 
 fn setup(mut commands: Commands) {
     commands.add(
-        KeySequence::new(action::send_event(MyEvent(1, None)), keyseq!(W D S A))
+        KeySequence::new(action::send_event(MyEvent(1, None)), keyseq! { W D S A })
             .time_limit(Duration::from_secs(5)),
     );
 
@@ -35,7 +35,7 @@ fn setup(mut commands: Commands) {
     );
 
     commands.add(
-        KeySequence::new(action::send_event(MyEvent(3, None)), keyseq!(W A S D))
+        KeySequence::new(action::send_event(MyEvent(3, None)), keyseq! { W A S D })
             .time_limit(Duration::from_secs(5)),
     );
 

--- a/examples/only_if.rs
+++ b/examples/only_if.rs
@@ -30,12 +30,12 @@ fn main() {
 fn setup(mut commands: Commands) {
     commands.add(KeySequence::new(
         action::send_event(GlobalEvent),
-        keyseq!(Escape),
+        keyseq! { Escape },
     ));
     commands.add(
         KeySequence::new(
             action::send_event(MyEvent).only_if(in_state(AppState::Game)),
-            keyseq!(Space),
+            keyseq! { Space },
         )
         .time_limit(Duration::from_secs(1)),
     );

--- a/examples/run_if.rs
+++ b/examples/run_if.rs
@@ -31,7 +31,7 @@ fn setup(mut commands: Commands) {
     commands.add(
         KeySequence::new(
             action::send_event(MyEvent).only_if(in_state(AppState::Game)),
-            keyseq!(Space),
+            keyseq! { Space },
         )
         .time_limit(Duration::from_secs(1)),
     );

--- a/src/action.rs
+++ b/src/action.rs
@@ -27,14 +27,14 @@ pub fn send_event<E: Event + Clone>(event: E) -> impl FnMut(EventWriter<E>) {
     }
 }
 
-/// Trigger and event.
+/// Trigger an event.
 pub fn trigger<E: Event + Clone>(event: E) -> impl FnMut(Commands) {
     move |mut commands: Commands| {
         commands.trigger(event.clone());
     }
 }
 
-/// Trigger and event with targets.
+/// Trigger an event with targets.
 pub fn trigger_targets<E: Event + Clone, T: TriggerTargets + Clone>(
     event: E,
     targets: T,

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,5 +1,7 @@
 //! Common actions to do on key sequence matches
 use bevy::ecs::{
+    prelude::{Commands},
+    observer::TriggerTargets,
     event::{Event, EventWriter},
     system::In,
 };
@@ -22,6 +24,20 @@ use bevy::ecs::{
 pub fn send_event<E: Event + Clone>(event: E) -> impl FnMut(EventWriter<E>) {
     move |mut writer: EventWriter<E>| {
         writer.send(event.clone());
+    }
+}
+
+/// Trigger and event.
+pub fn trigger<E: Event + Clone>(event: E) -> impl FnMut(Commands) {
+    move |mut commands: Commands| {
+        commands.trigger(event.clone());
+    }
+}
+
+/// Trigger and event with targets.
+pub fn trigger_targets<E: Event + Clone, T: TriggerTargets + Clone>(event: E, targets: T) -> impl FnMut(Commands) {
+    move |mut commands: Commands| {
+        commands.trigger_targets(event.clone(), targets.clone());
     }
 }
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,8 +1,8 @@
 //! Common actions to do on key sequence matches
 use bevy::ecs::{
-    prelude::{Commands},
-    observer::TriggerTargets,
     event::{Event, EventWriter},
+    observer::TriggerTargets,
+    prelude::Commands,
     system::In,
 };
 
@@ -35,7 +35,10 @@ pub fn trigger<E: Event + Clone>(event: E) -> impl FnMut(Commands) {
 }
 
 /// Trigger and event with targets.
-pub fn trigger_targets<E: Event + Clone, T: TriggerTargets + Clone>(event: E, targets: T) -> impl FnMut(Commands) {
+pub fn trigger_targets<E: Event + Clone, T: TriggerTargets + Clone>(
+    event: E,
+    targets: T,
+) -> impl FnMut(Commands) {
     move |mut commands: Commands| {
         commands.trigger_targets(event.clone(), targets.clone());
     }

--- a/src/chord.rs
+++ b/src/chord.rs
@@ -1,9 +1,8 @@
 use bevy::{
-    input::keyboard::KeyCode,
-    reflect::{Enum, Reflect},
+    input::keyboard::KeyCode, prelude::{Deref, DerefMut, Resource}, reflect::{Enum, Reflect}
 };
 
-use std::fmt;
+use std::{collections::VecDeque, fmt};
 
 use keyseq::Modifiers;
 
@@ -56,3 +55,10 @@ impl From<KeyCode> for KeyChord {
 pub(crate) fn is_modifier(key: KeyCode) -> bool {
     !Modifiers::from(key).is_empty()
 }
+
+/// Manually add key chords to be processed as through they were pressed by the
+/// user.
+///
+/// Normally this does not need to be manipulated. It is a kind of escape hatch.
+#[derive(Resource, Debug, Deref, DerefMut, Default)]
+pub struct KeyChordQueue(pub VecDeque<KeyChord>);

--- a/src/chord.rs
+++ b/src/chord.rs
@@ -1,5 +1,7 @@
 use bevy::{
-    input::keyboard::KeyCode, prelude::{Deref, DerefMut, Resource}, reflect::{Enum, Reflect}
+    input::keyboard::KeyCode,
+    prelude::{Deref, DerefMut, Resource},
+    reflect::{Enum, Reflect},
 };
 
 use std::{collections::VecDeque, fmt};

--- a/src/cond_system.rs
+++ b/src/cond_system.rs
@@ -34,7 +34,7 @@ pub trait IntoCondSystem<I, O, M>: IntoSystem<I, O, M> {
     }
 }
 
-impl<I, O, M, T> IntoCondSystem<I, O, M> for T where T: IntoSystem<I, O, M> + ?Sized {}
+impl<I, O, M, T> IntoCondSystem<I, O, M> for T where T: IntoSystem<I, O, M> {}
 
 /// A one-shot conditional system comprised of consequent `SystemA` and
 /// conditional `SystemB`.

--- a/src/input_sequence.rs
+++ b/src/input_sequence.rs
@@ -1,5 +1,6 @@
 //! Input sequences for keys and gamepad buttons
 use crate::{cond_system::IntoCondSystem, time_limit::TimeLimit, KeyChord};
+use std::fmt;
 
 use bevy::{
     ecs::{
@@ -24,6 +25,26 @@ pub struct InputSequence<Act, In> {
     pub acts: Vec<Act>,
     /// Optional time limit after first match
     pub time_limit: Option<TimeLimit>,
+}
+
+impl<Act: fmt::Debug, In> fmt::Debug for InputSequence<Act, In> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        #[derive(Debug)]
+        #[allow(dead_code)]
+        struct InputSequence<'a, Act> {
+            // system_id: SystemId<In>,
+            acts: &'a Vec<Act>,
+            time_limit: &'a Option<TimeLimit>,
+        }
+
+        let Self {
+            acts,
+            time_limit,
+            system_id: _,
+        } = self;
+
+        fmt::Debug::fmt(&InputSequence { acts, time_limit }, f)
+    }
 }
 
 /// An input sequence builder.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/bevy-input-sequence/0.5.0")]
+#![doc(html_root_url = "https://docs.rs/bevy-input-sequence/0.6.0")]
 #![doc = include_str!("../README.md")]
 #![forbid(missing_docs)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod plugin;
 mod time_limit;
 
 pub use chord::{KeyChord, KeyChordQueue};
-pub use plugin::{InputSequencePlugin};
+pub use plugin::InputSequencePlugin;
 pub use time_limit::TimeLimit;
 
 pub use keyseq::{
@@ -22,9 +22,9 @@ pub use keyseq::{
 
 /// Convenient glob import
 pub mod prelude {
+    pub use super::cond_system::IntoCondSystem;
     pub use super::input_sequence::{ButtonSequence, InputSequence, KeySequence};
     pub use super::{action, keyseq, InputSequencePlugin, Modifiers, TimeLimit};
-    pub use super::{KeyChordQueue, KeyChord};
-    pub use super::cond_system::IntoCondSystem;
+    pub use super::{KeyChord, KeyChordQueue};
     pub use std::time::Duration;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,6 @@
 #![doc = include_str!("../README.md")]
 #![forbid(missing_docs)]
 
-pub use chord::KeyChord;
-pub use plugin::InputSequencePlugin;
-pub use time_limit::TimeLimit;
-
 pub mod action;
 pub mod cache;
 mod chord;
@@ -14,6 +10,10 @@ mod frame_time;
 pub mod input_sequence;
 mod plugin;
 mod time_limit;
+
+pub use chord::{KeyChord, KeyChordQueue};
+pub use plugin::{InputSequencePlugin};
+pub use time_limit::TimeLimit;
 
 pub use keyseq::{
     bevy::{pkey as key, pkeyseq as keyseq},
@@ -24,8 +24,7 @@ pub use keyseq::{
 pub mod prelude {
     pub use super::input_sequence::{ButtonSequence, InputSequence, KeySequence};
     pub use super::{action, keyseq, InputSequencePlugin, Modifiers, TimeLimit};
-
-    pub use super::chord::KeyChord;
+    pub use super::{KeyChordQueue, KeyChord};
     pub use super::cond_system::IntoCondSystem;
     pub use std::time::Duration;
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -20,7 +20,7 @@ use std::collections::{HashMap, VecDeque};
 
 use crate::{
     cache::InputSequenceCache,
-    chord::{KeyChordQueue, is_modifier},
+    chord::{is_modifier, KeyChordQueue},
     frame_time::FrameTime,
     input_sequence::{ButtonSequence, InputSequence, KeySequence},
     KeyChord, Modifiers,
@@ -242,15 +242,17 @@ fn key_sequence_matcher(
         time: time.elapsed_seconds(),
     };
     let maybe_start = last_times.front().cloned();
-    let mut input = keychord_queue.drain(..).chain(
-        keys
-        .get_just_pressed()
-        .filter(|k| !is_modifier(**k))
-        .map(|k| {
-            let chord = KeyChord(mods, *k);
-            last_times.push_back(now.clone());
-            chord
-        }))
+    let mut input = keychord_queue
+        .drain(..)
+        .chain(
+            keys.get_just_pressed()
+                .filter(|k| !is_modifier(**k))
+                .map(|k| {
+                    let chord = KeyChord(mods, *k);
+                    last_times.push_back(now.clone());
+                    chord
+                }),
+        )
         .peekable();
     if input.peek().is_none() {
         return;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -20,7 +20,7 @@ use std::collections::{HashMap, VecDeque};
 
 use crate::{
     cache::InputSequenceCache,
-    chord::is_modifier,
+    chord::{KeyChordQueue, is_modifier},
     frame_time::FrameTime,
     input_sequence::{ButtonSequence, InputSequence, KeySequence},
     KeyChord, Modifiers,
@@ -53,6 +53,7 @@ impl Plugin for InputSequencePlugin {
         {
             // Add key sequence.
             app.init_resource::<InputSequenceCache<KeyChord, ()>>();
+            app.init_resource::<KeyChordQueue>();
 
             for (schedule, set) in &self.schedules {
                 if let Some(set) = set {
@@ -233,6 +234,7 @@ fn key_sequence_matcher(
     mut cache: ResMut<InputSequenceCache<KeyChord, ()>>,
     frame_count: Res<FrameCount>,
     mut commands: Commands,
+    mut keychord_queue: ResMut<KeyChordQueue>,
 ) {
     let mods = Modifiers::from(&keys);
     let now = FrameTime {
@@ -240,14 +242,15 @@ fn key_sequence_matcher(
         time: time.elapsed_seconds(),
     };
     let maybe_start = last_times.front().cloned();
-    let mut input = keys
+    let mut input = keychord_queue.drain(..).chain(
+        keys
         .get_just_pressed()
         .filter(|k| !is_modifier(**k))
         .map(|k| {
             let chord = KeyChord(mods, *k);
             last_times.push_back(now.clone());
             chord
-        })
+        }))
         .peekable();
     if input.peek().is_none() {
         return;
@@ -297,11 +300,22 @@ where
             None => {
                 search.reset();
                 // This could be the start of a new sequence.
-                if search.query(&k).is_none() {
-                    // This may not be necessary.
-                    search.reset();
+                //
+                // Let's check it.
+                match search.query(&k) {
+                    Some(Answer::Match) => {
+                        let result = Some(search.value().unwrap());
+                        search.reset();
+                        result
+                    }
+                    Some(Answer::PrefixAndMatch) => Some(search.value().unwrap()),
+                    Some(Answer::Prefix) => None,
+                    None => {
+                        // This may not be necessary.
+                        search.reset();
+                        None
+                    }
                 }
-                None
             }
         }
     })

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -234,7 +234,7 @@ fn key_sequence_matcher(
     frame_count: Res<FrameCount>,
     mut commands: Commands,
 ) {
-    let mods = Modifiers::from_input(&keys);
+    let mods = Modifiers::from(&keys);
     let now = FrameTime {
         frame: frame_count.0,
         time: time.elapsed_seconds(),

--- a/tests/act.rs
+++ b/tests/act.rs
@@ -33,131 +33,131 @@ fn eq_if_contains_key_in_lhs() {
 
 // #[test]
 // fn test_shifted_key_macro() {
-//     assert_eq!((Modifiers::CONTROL, KeyCode::KeyB), key! { ctrl-* });
+//     assert_eq!((Modifiers::CONTROL, KeyCode::KeyB), key! { Ctrl-* });
 // }
 
 /// XXX: This doc test isn't working.
 ///
 /// ```compile_fail
-/// assert_eq!((Modifiers::CONTROL, KeyCode::F2), key!{ ctrl-f2 });
+/// assert_eq!((Modifiers::CONTROL, KeyCode::F2), key!{ Ctrl-f2 });
 /// ```
 ///
 /// ```
-/// let _ = key! { ctrl-* });
+/// let _ = key! { Ctrl-* });
 /// ```
 #[allow(unused_must_use)]
 #[test]
 fn test_key_macro() {
-    assert_eq!((Modifiers::CONTROL, KeyCode::KeyB), key! { ctrl-B });
-    assert_eq!((Modifiers::CONTROL, KeyCode::Digit1), key! { ctrl-1 });
-    assert_eq!((Modifiers::CONTROL, KeyCode::Digit2), key! { ctrl-2 });
-    assert_eq!((Modifiers::CONTROL, KeyCode::F2), key! { ctrl-F2 });
-    // assert_eq!((Modifiers::CONTROL, KeyCode::F2), key!{ ctrl-f2 });
-    assert_eq!((Modifiers::CONTROL, KeyCode::Semicolon), key! { ctrl-; });
-    // assert_eq!((Modifiers::CONTROL, KeyCode::Caret), key! { ctrl-^ });
-    // assert_eq!((Modifiers::CONTROL, KeyCode::Colon), key! { ctrl-: });
-    assert_eq!((Modifiers::CONTROL, KeyCode::Equal), key! { ctrl-= });
-    assert_eq!((Modifiers::CONTROL, KeyCode::Comma), key! { ctrl-, });
-    assert_eq!((Modifiers::CONTROL, KeyCode::Period), key! { ctrl-. });
-    assert_eq!((Modifiers::CONTROL, KeyCode::Slash), key! { ctrl-/ });
-    assert_eq!((Modifiers::CONTROL, KeyCode::Enter), key! { ctrl-Enter });
-    assert_eq!((Modifiers::CONTROL, KeyCode::Space), key! { ctrl-Space });
-    assert_eq!((Modifiers::CONTROL, KeyCode::Tab), key! { ctrl-Tab });
-    assert_eq!((Modifiers::CONTROL, KeyCode::Delete), key! { ctrl-Delete });
-    assert_eq!((Modifiers::CONTROL, KeyCode::Minus), key! { ctrl-- });
+    assert_eq!((Modifiers::CONTROL, KeyCode::KeyB), key! { Ctrl-B });
+    assert_eq!((Modifiers::CONTROL, KeyCode::Digit1), key! { Ctrl-1 });
+    assert_eq!((Modifiers::CONTROL, KeyCode::Digit2), key! { Ctrl-2 });
+    assert_eq!((Modifiers::CONTROL, KeyCode::F2), key! { Ctrl-F2 });
+    // assert_eq!((Modifiers::CONTROL, KeyCode::F2), key!{ Ctrl-f2 });
+    assert_eq!((Modifiers::CONTROL, KeyCode::Semicolon), key! { Ctrl-; });
+    // assert_eq!((Modifiers::CONTROL, KeyCode::Caret), key! { Ctrl-^ });
+    // assert_eq!((Modifiers::CONTROL, KeyCode::Colon), key! { Ctrl-: });
+    assert_eq!((Modifiers::CONTROL, KeyCode::Equal), key! { Ctrl-= });
+    assert_eq!((Modifiers::CONTROL, KeyCode::Comma), key! { Ctrl-, });
+    assert_eq!((Modifiers::CONTROL, KeyCode::Period), key! { Ctrl-. });
+    assert_eq!((Modifiers::CONTROL, KeyCode::Slash), key! { Ctrl-/ });
+    assert_eq!((Modifiers::CONTROL, KeyCode::Enter), key! { Ctrl-Enter });
+    assert_eq!((Modifiers::CONTROL, KeyCode::Space), key! { Ctrl-Space });
+    assert_eq!((Modifiers::CONTROL, KeyCode::Tab), key! { Ctrl-Tab });
+    assert_eq!((Modifiers::CONTROL, KeyCode::Delete), key! { Ctrl-Delete });
+    assert_eq!((Modifiers::CONTROL, KeyCode::Minus), key! { Ctrl-- });
     assert_eq!(
         (Modifiers::CONTROL | Modifiers::SHIFT, KeyCode::Minus),
-        key! { ctrl-shift-- }
+        key! { Ctrl-Shift-- }
     );
-    // assert_eq!((Modifiers::CONTROL, KeyCode::Underline), key! { ctrl-_ });
+    // assert_eq!((Modifiers::CONTROL, KeyCode::Underline), key! { Ctrl-_ });
     // No colon key.
-    // assert_eq!((Modifiers::CONTROL, KeyCode::Colon), key! { ctrl-: });
+    // assert_eq!((Modifiers::CONTROL, KeyCode::Colon), key! { Ctrl-: });
     assert_eq!(
         (Modifiers::CONTROL | Modifiers::SHIFT, KeyCode::Semicolon),
-        key! { ctrl-shift-; }
+        key! { Ctrl-Shift-; }
     );
-    assert_eq!((Modifiers::CONTROL, KeyCode::Quote), key! { ctrl-'\'' });
+    assert_eq!((Modifiers::CONTROL, KeyCode::Quote), key! { Ctrl-'\'' });
 
     assert_eq!(
         (Modifiers::CONTROL | Modifiers::SHIFT, KeyCode::KeyA),
-        key! { ctrl-shift-A }
+        key! { Ctrl-Shift-A }
     );
-    // assert_eq!((Modifiers::CONTROL, KeyCode::KeyA), key!{ ctrl-A });
-    assert_eq!((Modifiers::SUPER, KeyCode::KeyA), key! { super-A });
-    assert_eq!((Modifiers::CONTROL, KeyCode::KeyA), key! { ctrl-A }); // Allow lowercase or demand lowercase?
+    // assert_eq!((Modifiers::CONTROL, KeyCode::KeyA), key!{ Ctrl-A });
+    assert_eq!((Modifiers::SUPER, KeyCode::KeyA), key! { Super-A });
+    assert_eq!((Modifiers::CONTROL, KeyCode::KeyA), key! { Ctrl-A }); // Allow lowercase or demand lowercase?
     assert_eq!((Modifiers::empty(), KeyCode::KeyA), key! { A });
     let k = (Modifiers::empty(), KeyCode::KeyA);
     assert_eq!(k, key! { A });
     // assert_eq!(
     //     (Modifiers::CONTROL, KeyCode::Asterisk),
-    //     key! { ctrl-Asterisk }
+    //     key! { Ctrl-Asterisk }
     // );
     assert_eq!(
         (Modifiers::CONTROL | Modifiers::SHIFT, KeyCode::Digit8),
-        key! { ctrl-shift-8 }
+        key! { Ctrl-Shift-8 }
     );
 
     assert_eq!(
         (Modifiers::CONTROL | Modifiers::SHIFT, KeyCode::Digit8),
-        key! { ctrl-shift-Digit8 }
+        key! { Ctrl-Shift-Digit8 }
     );
     // All bevy KeyCode names work.
-    // assert_eq!((Modifiers::CONTROL, KeyCode::Asterisk), key! { ctrl-* }); // with some short hand.
+    // assert_eq!((Modifiers::CONTROL, KeyCode::Asterisk), key! { Ctrl-* }); // with some short hand.
 
-    // assert_eq!((Modifiers::CONTROL, KeyCode::Plus), key! { ctrl-+ });
+    // assert_eq!((Modifiers::CONTROL, KeyCode::Plus), key! { Ctrl-+ });
     assert_eq!(
         (Modifiers::CONTROL | Modifiers::SHIFT, KeyCode::Equal),
-        key! { ctrl-shift-= }
+        key! { Ctrl-Shift-= }
     );
-    // assert_eq!((Modifiers::CONTROL, KeyCode::At), key! { ctrl-@ });
+    // assert_eq!((Modifiers::CONTROL, KeyCode::At), key! { Ctrl-@ });
     assert_eq!(
         (Modifiers::CONTROL, KeyCode::BracketLeft),
-        key! { ctrl-'[' }
+        key! { Ctrl-'[' }
     );
     assert_eq!(
         (Modifiers::CONTROL, KeyCode::BracketRight),
-        key! { ctrl-']' }
+        key! { Ctrl-']' }
     );
     assert_eq!(
         (Modifiers::CONTROL, KeyCode::BracketRight),
-        key! { ctrl-']' }
+        key! { Ctrl-']' }
     );
-    assert_eq!((Modifiers::CONTROL, KeyCode::Backquote), key! { ctrl-'`' });
-    assert_eq!((Modifiers::CONTROL, KeyCode::Backslash), key! { ctrl-'\\' });
-    assert_eq!((Modifiers::CONTROL, KeyCode::Escape), key! { ctrl-Escape });
-    // assert_eq!((Modifiers::CONTROL, KeyCode::Escape), key!{ ctrl-Esc });
+    assert_eq!((Modifiers::CONTROL, KeyCode::Backquote), key! { Ctrl-'`' });
+    assert_eq!((Modifiers::CONTROL, KeyCode::Backslash), key! { Ctrl-'\\' });
+    assert_eq!((Modifiers::CONTROL, KeyCode::Escape), key! { Ctrl-Escape });
+    // assert_eq!((Modifiers::CONTROL, KeyCode::Escape), key!{ Ctrl-Esc });
     assert_eq!(
         (Modifiers::CONTROL | Modifiers::ALT, KeyCode::KeyA),
-        key! { ctrl-alt-A }
+        key! { Ctrl-Alt-A }
     );
 
     assert_eq!((Modifiers::empty(), KeyCode::KeyA), key! { A });
     assert_eq!(
         (Modifiers::CONTROL | Modifiers::ALT, KeyCode::KeyA),
-        key! { ctrl-alt-A }
+        key! { Ctrl-Alt-A }
     );
     assert_eq!(
         (Modifiers::CONTROL | Modifiers::ALT, KeyCode::KeyA),
-        key! { ctrl-alt-A }
+        key! { Ctrl-Alt-A }
     );
     assert_eq!(
         (Modifiers::CONTROL | Modifiers::ALT, KeyCode::Semicolon),
-        key! { ctrl-alt-Semicolon }
+        key! { Ctrl-Alt-Semicolon }
     );
     assert_eq!(
         (Modifiers::CONTROL | Modifiers::ALT, KeyCode::Semicolon),
-        key! { ctrl-alt-; }
+        key! { Ctrl-Alt-; }
     );
     assert_eq!(
         (
             Modifiers::CONTROL | Modifiers::ALT | Modifiers::SHIFT,
             KeyCode::Semicolon
         ),
-        key! { ctrl-alt-shift-; } // ctrl-alt-:
+        key! { Ctrl-Alt-Shift-; } // Ctrl-Alt-:
     );
     assert_eq!(
         (Modifiers::CONTROL | Modifiers::ALT, KeyCode::Slash),
-        key! { ctrl-alt-/ }
+        key! { Ctrl-Alt-/ }
     );
 }
 
@@ -166,18 +166,18 @@ fn test_key_macro() {
 fn test_keyseq() {
     assert_eq!(
         vec![(Modifiers::CONTROL, KeyCode::KeyA)],
-        keyseq! { ctrl-A }
+        keyseq! { Ctrl-A }
     );
     assert_eq!(
         vec![(Modifiers::CONTROL, KeyCode::KeyA)],
-        keyseq! { ctrl-ctrl-A }
+        keyseq! { Ctrl-Ctrl-A }
     );
     assert_eq!(
         vec![
             (Modifiers::CONTROL, KeyCode::KeyA),
             (Modifiers::ALT, KeyCode::KeyB)
         ],
-        keyseq! { ctrl-A alt-B }
+        keyseq! { Ctrl-A Alt-B }
     );
 
     assert_eq!(

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -11,25 +11,25 @@ fn test_keyseq_doc() {
         ]
     );
     assert_eq!(
-        keyseq! { ctrl-A B },
+        keyseq! { Ctrl-A B },
         [
             (Modifiers::CONTROL, KeyCode::KeyA),
             (Modifiers::empty(), KeyCode::KeyB)
         ]
     );
     assert_eq!(
-        keyseq! { ctrl-alt-A Escape },
+        keyseq! { Ctrl-Alt-A Escape },
         [
             (Modifiers::ALT | Modifiers::CONTROL, KeyCode::KeyA),
             (Modifiers::empty(), KeyCode::Escape)
         ]
     );
     assert_eq!(
-        keyseq! { ctrl-; },
+        keyseq! { Ctrl-; },
         [(Modifiers::CONTROL, KeyCode::Semicolon)]
     );
     assert_eq!(
-        keyseq! { ctrl-Semicolon },
+        keyseq! { Ctrl-Semicolon },
         [(Modifiers::CONTROL, KeyCode::Semicolon)]
     );
 }

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,6 +1,62 @@
 use bevy::prelude::*;
 use bevy_input_sequence::*;
 
+#[rustfmt::skip]
+#[test]
+fn before_cargo_format() {
+    assert_eq!(
+        [key![Ctrl-A],
+         key! [Ctrl-A],
+         key! [ Ctrl-A ],
+         key!{Ctrl-A},
+         key! {Ctrl-A},
+         key! { Ctrl-A },
+         key!(Ctrl-A),
+         key! (Ctrl-A),
+         key! ( Ctrl-A ),
+        ],
+        [
+            (Modifiers::CONTROL, KeyCode::KeyA),
+            (Modifiers::CONTROL, KeyCode::KeyA),
+            (Modifiers::CONTROL, KeyCode::KeyA),
+            (Modifiers::CONTROL, KeyCode::KeyA),
+            (Modifiers::CONTROL, KeyCode::KeyA),
+            (Modifiers::CONTROL, KeyCode::KeyA),
+            (Modifiers::CONTROL, KeyCode::KeyA),
+            (Modifiers::CONTROL, KeyCode::KeyA),
+            (Modifiers::CONTROL, KeyCode::KeyA),
+        ]
+    );
+}
+
+#[test]
+fn after_cargo_format() {
+    assert_eq!(
+        [
+            key![Ctrl - A],
+            key![Ctrl - A],
+            key![Ctrl - A],
+            key! {Ctrl-A},
+            key! {Ctrl-A},
+            key! { Ctrl-A },
+            key!(Ctrl - A),
+            key!(Ctrl - A),
+            key!(Ctrl - A),
+        ],
+        [
+            (Modifiers::CONTROL, KeyCode::KeyA),
+            (Modifiers::CONTROL, KeyCode::KeyA),
+            (Modifiers::CONTROL, KeyCode::KeyA),
+            (Modifiers::CONTROL, KeyCode::KeyA),
+            (Modifiers::CONTROL, KeyCode::KeyA),
+            (Modifiers::CONTROL, KeyCode::KeyA),
+            (Modifiers::CONTROL, KeyCode::KeyA),
+            (Modifiers::CONTROL, KeyCode::KeyA),
+            (Modifiers::CONTROL, KeyCode::KeyA),
+        ]
+    );
+}
+
 #[test]
 fn test_keyseq_doc() {
     assert_eq!(

--- a/tests/simulated.rs
+++ b/tests/simulated.rs
@@ -30,7 +30,7 @@ mod simulate_app {
             keyboard::KeyCode,
             Axis, ButtonInput as Input,
         },
-        prelude::{Resource, Commands, ResMut},
+        prelude::{Commands, ResMut, Resource},
         MinimalPlugins,
     };
     use bevy_input_sequence::prelude::*;
@@ -261,18 +261,12 @@ mod simulate_app {
     fn match_a_and_c() {
         let mut app = new_app();
 
-        app.world_mut().add(KeySequence::new(
-            set(1),
-            [KeyCode::KeyA],
-        ));
-        app.world_mut().add(KeySequence::new(
-            set(2),
-            [KeyCode::KeyA, KeyCode::KeyB],
-        ));
-        app.world_mut().add(KeySequence::new(
-            set(3),
-            [KeyCode::KeyC],
-        ));
+        app.world_mut()
+            .add(KeySequence::new(set(1), [KeyCode::KeyA]));
+        app.world_mut()
+            .add(KeySequence::new(set(2), [KeyCode::KeyA, KeyCode::KeyB]));
+        app.world_mut()
+            .add(KeySequence::new(set(3), [KeyCode::KeyC]));
         assert_eq!(get(app.world()), 0);
         press_key(&mut app, KeyCode::KeyA);
         app.update();

--- a/tests/simulated.rs
+++ b/tests/simulated.rs
@@ -2,10 +2,10 @@ use bevy_input_sequence::{key, KeyChord};
 
 #[test]
 fn keychord_display() {
-    let keychord = KeyChord::from(key!(ctrl - A));
-    assert_eq!(format!("{}", keychord), "ctrl-A");
-    let keychord = KeyChord::from(key!(ctrl - 1));
-    assert_eq!(format!("{}", keychord), "ctrl-1");
+    let keychord = KeyChord::from(key!(Ctrl - A));
+    assert_eq!(format!("{}", keychord), "Ctrl-A");
+    let keychord = KeyChord::from(key!(Ctrl - 1));
+    assert_eq!(format!("{}", keychord), "Ctrl-1");
     let keychord = KeyChord::from(key!(1));
     assert_eq!(format!("{}", keychord), "1");
 }

--- a/tests/simulated.rs
+++ b/tests/simulated.rs
@@ -243,6 +243,41 @@ mod simulate_app {
             .next()
             .is_some());
     }
+    #[test]
+    fn match_ab_and_c() {
+        let mut app = new_app();
+
+        app.world_mut().add(KeySequence::new(
+            action::send_event(EventSent(0)),
+            [KeyCode::KeyA, KeyCode::KeyB],
+        ));
+        app.world_mut().add(KeySequence::new(
+            action::send_event(EventSent(1)),
+            [KeyCode::KeyA],
+        ));
+        app.world_mut().add(KeySequence::new(
+            action::send_event(EventSent(2)),
+            [KeyCode::KeyC],
+        ));
+        press_key(&mut app, KeyCode::KeyA);
+        app.update();
+        assert!(app
+            .world_mut()
+            .query::<&EventSent>()
+            .iter(app.world_mut())
+            .next()
+            .is_none());
+
+        clear_just_pressed(&mut app, KeyCode::KeyA);
+        press_key(&mut app, KeyCode::KeyB);
+        app.update();
+        assert!(app
+                .world_mut()
+                .query::<&EventSent>()
+                .iter(app.world_mut())
+                .next()
+                .map(|x| x.0 == 0).unwrap_or(false));
+    }
 
     #[test]
     fn two_any_patterns() {

--- a/tests/simulated.rs
+++ b/tests/simulated.rs
@@ -64,7 +64,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_some());
     }
@@ -86,7 +86,7 @@ mod simulate_app {
         assert_eq!(
             app.world_mut()
                 .query::<&EventSent>()
-                .iter(&app.world_mut())
+                .iter(app.world_mut())
                 .count(),
             1
         );
@@ -110,7 +110,7 @@ mod simulate_app {
         assert_eq!(
             app.world_mut()
                 .query::<&EventSent>()
-                .iter(&app.world_mut())
+                .iter(app.world_mut())
                 .count(),
             2
         );
@@ -134,7 +134,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
 
@@ -144,7 +144,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_some());
     }
@@ -167,7 +167,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
 
@@ -177,7 +177,7 @@ mod simulate_app {
         assert_eq!(
             app.world_mut()
                 .query::<&EventSent>()
-                .iter(&app.world_mut())
+                .iter(app.world_mut())
                 .next()
                 .map(|x| x.0)
                 .unwrap(),
@@ -190,7 +190,7 @@ mod simulate_app {
         assert_eq!(
             app.world_mut()
                 .query::<&EventSent>()
-                .iter(&app.world_mut())
+                .iter(app.world_mut())
                 .next()
                 .map(|x| x.0)
                 .unwrap(),
@@ -203,7 +203,7 @@ mod simulate_app {
         assert_eq!(
             app.world_mut()
                 .query::<&EventSent>()
-                .iter(&app.world_mut())
+                .iter(app.world_mut())
                 .next()
                 .map(|x| x.0)
                 .unwrap(),
@@ -229,7 +229,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
 
@@ -239,7 +239,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_some());
     }
@@ -265,7 +265,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
 
@@ -275,7 +275,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_some());
     }
@@ -301,7 +301,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
 
@@ -311,7 +311,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_some());
     }
@@ -330,7 +330,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
 
@@ -340,7 +340,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_some());
     }
@@ -359,7 +359,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
 
@@ -369,7 +369,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
 
@@ -379,7 +379,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
     }
@@ -409,7 +409,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
 
@@ -419,7 +419,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
 
@@ -429,7 +429,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_some());
     }
@@ -470,7 +470,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
 
@@ -480,7 +480,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
 
@@ -490,7 +490,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
 
@@ -500,7 +500,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_some());
     }
@@ -520,7 +520,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
 
@@ -534,7 +534,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
     }
@@ -553,7 +553,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
 
@@ -565,7 +565,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
         release(&mut app, KeyCode::ControlLeft);
@@ -576,7 +576,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_some());
     }
@@ -595,7 +595,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
 
@@ -607,7 +607,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_some());
     }
@@ -629,7 +629,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
 
@@ -641,7 +641,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
 
@@ -650,7 +650,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
 
@@ -658,7 +658,7 @@ mod simulate_app {
         assert!(app
             .world_mut()
             .query::<&EventSent>()
-            .iter(&app.world_mut())
+            .iter(app.world_mut())
             .next()
             .is_none());
     }


### PR DESCRIPTION
Hey Elm,

I added some convenience methods to trigger events instead of sending them. But that's not my whopper.

My whopper is that I changed keyseq and published 0.4.0. After a lot of [deliberation](https://github.com/shanecelis/keyseq/blob/main/CHANGELOG.md), I decided to switch to capitalized modifier keys, so `Ctrl-A` instead of `ctrl-A`. I also added a feature flag to permit the even more standard `Ctrl+A`. This change breaks any keyseq users, which right now is only this crate, so I say break 'em while they're small.

My hope is to get `bevy-input-sequence` out the door and then push my first release of [bevy_minibuffer](https://github.com/shanecelis/bevy_minibuffer) for bevy 0.14 before bevy 0.15 gets published, which may be as soon as this weekend.

If you don't viscerally object to the notation change, let me know how I can help. If you're ok with this PR and permit it, I can publish to crates.io since we're both owners. That's purely an offer to help and expedite if you lack time or access.

Be well!

-Shane