### PR TITLE
Fix the docs.rs build.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.8.1] - 2025-04-28
+
+- Fix docs.rs build
+
+## [0.8.0] - 2025-04-27
+
+- Add support for bevy v0.16
+
 ## [0.7.0] - 2024-12-09
 
 - Add support for bevy v0.15

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "bevy-input-sequence"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bevy",
  "keyseq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy-input-sequence"
 description = "Recognizes and acts on input sequences"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 authors = ["elm", "Shane Celis <shane.celis@gmail.com>"]
 keywords = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,9 @@ keyseq = { version = "0.6.0", features = [ "bevy" ] }
 bevy = "0.16"
 trybuild = "1.0"
 version-sync = "0.9"
+
+[features]
+x11 = ["bevy/x11"]
+
+[package.metadata.docs.rs]
+features = ["x11"]

--- a/src/cond_system.rs
+++ b/src/cond_system.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 /// Extend [IntoSystem] to allow for some conditional execution. Probably only
 /// appropriate for one-shot systems. Prefer
-/// [`run_if()`](bevy::ecs::schedule::IntoSystemConfigs::run_if()) when directly
+/// [`run_if()`](bevy::ecs::schedule::IntoScheduleConfigs::run_if()) when directly
 /// adding to the scheduler.
 pub trait IntoCondSystem<I, O, M>: IntoSystem<I, O, M>
 where

--- a/src/input_sequence.rs
+++ b/src/input_sequence.rs
@@ -18,8 +18,9 @@ use bevy::{
 /// An input sequence is a series of acts that fires an event when matched with
 /// inputs within the given time limit.
 ///
-/// InputSequence<KeyChord, ()>
-/// InputSequence<GamepadButton, In<Entity>>
+/// `InputSequence<KeyChord, ()>`, a keychord sequence doesn't have an input,
+/// but a gamepad `InputSequence<GamepadButton, In<Entity>>` provides an entity
+/// for the controller the input came from.
 #[derive(Component, Reflect)]
 #[reflect(from_reflect = false)]
 pub struct InputSequence<Act, I: SystemInput + 'static> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/bevy-input-sequence/0.8.0")]
+#![doc(html_root_url = "https://docs.rs/bevy-input-sequence/0.8.1")]
 #![doc = include_str!("../README.md")]
 #![forbid(missing_docs)]
 


### PR DESCRIPTION
The [docs.rs hasn't been building](https://docs.rs/crate/bevy-input-sequence/0.8.0) because winit needs a platform. I fixed it and published 0.8.1 and the docs are working!