### PR TITLE
chore: Update GitHub Actions to include pkg-config in installation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev pkg-config
       - name: Checkout
         uses: actions/checkout@v3
       - name: Toolchain
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev pkg-config
       - name: Checkout
         uses: actions/checkout@v3
       - name: Toolchain


### PR DESCRIPTION
## Summary
- Add `pkg-config` to the apt-get install commands in CI workflow
- Add missing `libwayland-dev` and `libxkbcommon-dev` dependencies to the test job

These dependencies are required for building Bevy projects on Ubuntu and were causing CI failures.

## Test plan
- [ ] Verify CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)